### PR TITLE
Add UI and backend flow to hatch all ready eggs

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,12 +47,17 @@
     .player-card{ padding:10px 12px; margin:8px 0; border-radius:8px; border:1px solid var(--border); cursor:pointer; background:#3a5066; transition:.15s; }
     .player-card:hover{ transform:translateY(-1px); box-shadow:0 4px 10px rgba(0,0,0,.15) }
     .player-card.active{ outline:2px solid var(--primary); box-shadow:0 0 0 2px rgba(52,152,219,.3) inset }
+    .player-card.other{ cursor:default; opacity:.78; background:#33475f; }
+    .player-card.other:hover{ transform:none; box-shadow:none; }
     .player-name{ font-weight:700; display:flex; align-items:center; gap:8px; }
     .online-badge{ font-size:11px; font-weight:700; letter-spacing:.2px; padding:2px 6px; border-radius:999px; background:rgba(39,174,96,.15); color:#b6f3c8; border:1px solid rgba(39,174,96,.35); }
+    .online-badge.other{ background:rgba(149,165,166,.18); border-color:rgba(149,165,166,.45); color:#e4ebf5; }
     .player-sub{ margin-top:6px; font-size:12px; color:#d6e2ee; display:flex; flex-direction:column; gap:4px; }
-    .coin-line,.limit-line{ display:flex; align-items:center; gap:6px; color:#e3eef9; }
+    .coin-line,.limit-line,.income-line{ display:flex; align-items:center; gap:6px; color:#e3eef9; }
     .coin-line::before{ content:"💰"; opacity:.9 }
     .limit-line::before{ content:"🎁"; opacity:.9 }
+    .income-line::before{ content:"🌾"; opacity:.9 }
+    .income-line{ white-space:pre-line; }
 
     .chip{ display:inline-flex; align-items:center; gap:6px; padding:2px 8px; border-radius:999px; background:#223445; border:1px solid #3c556e; font-size:12px; }
     .summary-line{ display:flex; align-items:flex-start; gap:6px; flex-wrap:wrap; margin-top:6px; }
@@ -373,6 +378,7 @@
     let selectedPlayer = null;
     let expandedRooms = new Set();
     let roomsAutoExpanded = new Set();
+    let latestRooms = [];
     const DAILY_LIMIT = 500;
 
     let msSideEggTypes=null, msSideMutas=null, msSideFoods=null;
@@ -381,7 +387,20 @@
 
     const nowSec = ()=>Math.floor(Date.now()/1000);
     const toInt = (v,d=0)=>{ const n=Number(v); return Number.isFinite(n)?n:d; };
+    const escapeHtml = (s)=> String(s ?? '').replace(/[&<>"']/g, c=>({
+      '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'
+    })[c] || c);
     const coinsStr = (pd)=> toInt(pd?.coin,0).toLocaleString();
+    const farmIncomeDisplay = (pd)=>{
+      const value = Number(pd?.farmIncomePerSec);
+      if(!Number.isFinite(value) || value <= 0) return '';
+      let formatOptions;
+      if (value >= 100) formatOptions = { maximumFractionDigits: 0 };
+      else if (value >= 10) formatOptions = { maximumFractionDigits: 1 };
+      else formatOptions = { maximumFractionDigits: 2 };
+      const formatted = value.toLocaleString(undefined, formatOptions);
+      return `${formatted} /s`;
+    };
 
     const isOnline = (pd)=>{
       if(!pd || !pd.serverLastSeen) return false;
@@ -470,18 +489,66 @@
 
     /* ======= Group by Room ======= */
     function groupByRoom(){
-      const names=onlyOnlineNames(); const groups=new Map();
+      const names = onlyOnlineNames();
+      if(names.length === 0){ latestRooms = []; return []; }
+
+      const nameSet = new Set(names);
+      const visited = new Set();
+      const rooms = [];
+
       for(const name of names){
-        const serverList=playersData[name]?.serverPlayerList||[];
-        const inRoom=serverList.filter(n=>names.includes(n));
-        if(!inRoom.includes(name)) inRoom.push(name);
-        const key=JSON.stringify(inRoom.sort());
-        if(!groups.has(key)) groups.set(key,{members:[]});
-        groups.get(key).members.push(name);
+        if(visited.has(name)) continue;
+
+        const stack = [name];
+        const memberSet = new Set();
+        const othersSet = new Set();
+
+        while(stack.length){
+          const current = stack.pop();
+          if(visited.has(current)) continue;
+
+          visited.add(current);
+          memberSet.add(current);
+
+          const serverList = playersData[current]?.serverPlayerList || [];
+          for(const raw of serverList){
+            if(raw == null) continue;
+            const otherName = typeof raw === 'string' ? raw.trim() : String(raw).trim();
+            if(!otherName) continue;
+
+            if(nameSet.has(otherName)){
+              if(!visited.has(otherName)) stack.push(otherName);
+            }else{
+              othersSet.add(otherName);
+            }
+          }
+        }
+
+        const members = Array.from(memberSet).sort((a,b)=>a.localeCompare(b));
+        const others = Array.from(othersSet).sort((a,b)=>a.localeCompare(b));
+        const signature = JSON.stringify({members, others});
+        rooms.push({ roomId: hashShort(signature), members, others });
       }
-      return Array.from(groups.entries())
-        .map(([k,v])=>({roomKey:k, roomId:hashShort(k), members:v.members.sort()}))
-        .sort((a,b)=>b.members.length-a.members.length);
+
+      rooms.sort((a,b)=>{
+        const totalA = a.members.length + a.others.length;
+        const totalB = b.members.length + b.others.length;
+        if(totalB !== totalA) return totalB - totalA;
+        if(b.members.length !== a.members.length) return b.members.length - a.members.length;
+        return a.roomId.localeCompare(b.roomId);
+      });
+
+      latestRooms = rooms;
+      return rooms;
+    }
+
+    function getRoomInfo(name){
+      if(!name) return null;
+      if(!latestRooms.some(r=>r.members.includes(name))){
+        const rooms = groupByRoom();
+        if(!rooms.length) return null;
+      }
+      return latestRooms.find(r=>r.members.includes(name)) || null;
     }
 
     /* ======= Aggregate helpers ======= */
@@ -516,8 +583,10 @@
       if(groups.length===0){ wrap.innerHTML=`<div class="muted" style="padding:6px 8px;">ไม่มีผู้ใช้สคริปต์ที่ออนไลน์</div>`; return; }
 
       for(const g of groups){
-        const roomMembers=[...new Set(JSON.parse(g.roomKey))];
+        const roomMembers=g.members;
+        const roomOthers=g.others;
         const roomId=g.roomId;
+        const totalPlayers=roomMembers.length+roomOthers.length;
 
         // auto-expand ครั้งเดียวต่อห้อง
         if (selectedPlayer && roomMembers.includes(selectedPlayer) && !expandedRooms.has(roomId) && !roomsAutoExpanded.has(roomId)) {
@@ -531,7 +600,8 @@
         const header=document.createElement('div');
         const open=expandedRooms.has(roomId);
         header.className='room-header clickable';
-        header.innerHTML=`<span class="caret ${open?'open':''}">▸</span> Room <span class="room-pill">${roomId}</span> • ${roomMembers.length} players`;
+        header.innerHTML=`<span class="caret ${open?'open':''}">▸</span> Room <span class="room-pill">${roomId}</span> • ${totalPlayers} players${roomOthers.length?` <span class="muted">(Other ${roomOthers.length})</span>`:''}`;
+        header.title = `Script: ${roomMembers.length}${roomOthers.length?`, Other: ${roomOthers.length}`:''}`;
         header.onclick=()=>{ if(expandedRooms.has(roomId)) expandedRooms.delete(roomId); else expandedRooms.add(roomId); renderPlayerList(); };
         section.appendChild(header);
 
@@ -543,21 +613,31 @@
 
         const details=document.createElement('div'); details.className='room-details'; details.style.display=open?'':'none';
         if(open){
-          const onlineSet=new Set(onlyOnlineNames());
-          const members=roomMembers.filter(n=>onlineSet.has(n)).sort();
-          for(const name of members){
+          for(const name of roomMembers){
             const d=playersData[name]; const sl=getSlim(d);
             const eggList=(sl.eggsAgg||[]).filter(x=>passesEggVisibility(x.type,x.muta));
             const foodList=(sl.foods||[]).filter(x=>passesFoodVisibility(x.name));
             const card=document.createElement('div'); card.className='player-card'+(name===selectedPlayer?' active':'');
-            card.innerHTML=`<div class="player-name"><span>${name}</span><span class="online-badge">ONLINE</span></div>
+            const farmIncomeText = farmIncomeDisplay(d);
+            card.innerHTML=`<div class="player-name"><span>${escapeHtml(name)}</span><span class="online-badge">ONLINE</span></div>
               <div class="player-sub">
                 <div class="coin-line">${coinsStr(d)}</div>
                 <div class="limit-line">${toInt(d?.todayGiftCount,0)} / ${DAILY_LIMIT}</div>
+                ${farmIncomeText?`<div class="income-line">${escapeHtml(farmIncomeText)}</div>`:''}
                 ${eggList.length?`<div class="summary-line"><span class="label">🥚</span>${eggList.slice(0,6).map(g=>`<span class="chip">${g.type}/${g.muta} × ${g.count}</span>`).join(' ')}${eggList.length>6?`<span class="chip">+${eggList.length-6}</span>`:''}</div>`:''}
                 ${foodList.length?`<div class="summary-line"><span class="label">🍓</span>${foodList.slice(0,6).map(f=>`<span class="chip">${f.name} × ${f.qty}</span>`).join(' ')}${foodList.length>6?`<span class="chip">+${foodList.length-6}</span>`:''}</div>`:''}
               </div>`;
             card.onclick=(e)=>{ selectedPlayer = (selectedPlayer===name)? null : name; renderAll(); e.stopPropagation(); };
+            details.appendChild(card);
+          }
+
+          for(const otherName of roomOthers){
+            const card=document.createElement('div'); card.className='player-card other';
+            card.innerHTML=`<div class="player-name"><span>${escapeHtml(otherName)} <span class="muted">(Other)</span></span><span class="online-badge other">OTHER</span></div>
+              <div class="player-sub muted">
+                <div>ไม่ใช้สคริปต์ • ไม่มีข้อมูลเพิ่มเติม</div>
+              </div>`;
+            card.onclick=(e)=>e.stopPropagation();
             details.appendChild(card);
           }
         }
@@ -568,11 +648,6 @@
     }
 
     /* ======= Center Overview ======= */
-    function roomNamesOfSelected(){
-      if(!selectedPlayer || !playersData[selectedPlayer]) return [];
-      const online=new Set(onlyOnlineNames()); const room=playersData[selectedPlayer]?.serverPlayerList||[];
-      return room.filter(n=>online.has(n));
-    }
     function renderCenter(){
       const title=document.getElementById('sel-title'), sub=document.getElementById('sel-sub'), metrics=document.getElementById('sel-metrics');
       const roomSub=document.getElementById('room-sub'), roomEggs=document.getElementById('room-eggs'), roomFoods=document.getElementById('room-foods');
@@ -584,13 +659,28 @@
 
       const me=playersData[selectedPlayer]; const sl=getSlim(me);
       title.textContent=`Selected: ${selectedPlayer}`; sub.textContent='เปิด Trade System หรือ Egg Distributor ได้จากปุ่มด้านขวา';
-      metrics.innerHTML=`<div class="metric"><div class="k">Coins</div><div class="v">${coinsStr(me)}</div></div>
-        <div class="metric"><div class="k">ส่งของวันนี้</div><div class="v">${toInt(me?.todayGiftCount,0)} / ${DAILY_LIMIT}</div></div>
-        <div class="metric"><div class="k">ไข่ที่ยังไม่วาง</div><div class="v">${toInt(sl?.eggsUnplaced,0)}</div></div>
-        <div class="metric"><div class="k">สัตว์ (ยังไม่วาง)</div><div class="v">${toInt(sl?.petsUnplaced,0)}</div></div>`;
+      const metricBlocks = [
+        `<div class="metric"><div class="k">Coins</div><div class="v">${coinsStr(me)}</div></div>`,
+        `<div class="metric"><div class="k">ส่งของวันนี้</div><div class="v">${toInt(me?.todayGiftCount,0)} / ${DAILY_LIMIT}</div></div>`,
+        `<div class="metric"><div class="k">ไข่ที่ยังไม่วาง</div><div class="v">${toInt(sl?.eggsUnplaced,0)}</div></div>`,
+        `<div class="metric"><div class="k">สัตว์ (ยังไม่วาง)</div><div class="v">${toInt(sl?.petsUnplaced,0)}</div></div>`
+      ];
+      const farmIncomeText = farmIncomeDisplay(me);
+      metricBlocks.push(`<div class="metric"><div class="k">รายได้ฟาร์ม</div><div class="v">${farmIncomeText?escapeHtml(farmIncomeText):'-'}</div></div>`);
+      metrics.innerHTML = metricBlocks.join('');
 
-      const rnames=roomNamesOfSelected(); const roomId=hashShort(JSON.stringify(rnames.slice().sort()));
-      roomSub.textContent=rnames.length?`Room ${roomId} • ${rnames.length} players`:'ไม่พบรายชื่อผู้เล่นในห้อง';
+      const roomInfo = getRoomInfo(selectedPlayer);
+      if(!roomInfo){
+        roomSub.textContent='ไม่พบรายชื่อผู้เล่นในห้อง';
+        roomEggs.innerHTML='<span class="muted">—</span>';
+        roomFoods.innerHTML='<span class="muted">—</span>';
+        return;
+      }
+
+      const rnames = roomInfo.members.slice();
+      const totalPlayers = rnames.length + roomInfo.others.length;
+      const otherPart = roomInfo.others.length ? ` (${rnames.length} script, ${roomInfo.others.length} other)` : '';
+      roomSub.textContent = `Room ${roomInfo.roomId} • ${totalPlayers} players${otherPart}`;
 
       const eggMap=new Map(), foodMap=new Map();
       for(const n of rnames){
@@ -625,6 +715,29 @@
         const full=getFull(pd); const sl=getSlim(pd);
 
         if(tab==='eggs'){
+          const readyEggs = (full?.eggs||[]).filter(e=>e.readyToHatch && e.uid);
+          if(full){
+            if(readyEggs.length){
+              const hatchBtn=document.createElement('button');
+              hatchBtn.className='btn';
+              hatchBtn.textContent=`ฟักไข่พร้อม (${readyEggs.length})`;
+              hatchBtn.onclick=()=>hatchReadyEggsForSelected(readyEggs.map(e=>e.uid));
+              tools.appendChild(hatchBtn);
+            }else{
+              const note=document.createElement('div');
+              note.className='muted';
+              note.style.padding='6px 0';
+              note.textContent='ไม่มีไข่ที่พร้อมฟัก';
+              tools.appendChild(note);
+            }
+          }else{
+            const note=document.createElement('div');
+            note.className='muted';
+            note.style.padding='6px 0';
+            note.textContent='กำลังโหลดข้อมูลเต็ม...';
+            tools.appendChild(note);
+          }
+
           const rows = full ? (()=>{ const map=new Map(); (full.eggs||[]).forEach(e=>{ if(e.placed) return; const k=`${e.type}|${e.mutation||'None'}`; map.set(k,(map.get(k)||0)+1); }); return Array.from(map.entries()).map(([k,c])=>{const [t,m]=k.split('|'); return{type:t,muta:m,count:c};}).sort((a,b)=>b.count-a.count||a.type.localeCompare(b.type)); })() : (sl.eggsAgg||[]);
           if(!rows || rows.length===0){ list.innerHTML='<div class="muted" style="padding:10px;">กำลังโหลดข้อมูลเต็มหรือไม่มีรายการ</div>'; }
           else rows.forEach(r=>{ const row=document.createElement('div'); row.className='row'; row.innerHTML=`<div class="grow"><b>${r.type}</b> <span class="chip">${r.muta}</span></div><div><b>${r.count}</b></div>`; list.appendChild(row); });
@@ -642,6 +755,47 @@
     }
 
     /* ======= Trade ======= */
+    async function hatchReadyEggsForSelected(uids){
+      if(!selectedPlayer){ alert('โปรดเลือกผู้เล่นก่อน'); return; }
+      const uniqueUIDs=[...new Set((uids||[]).filter(uid=>typeof uid==='string'&&uid.trim().length>0))];
+      if(uniqueUIDs.length===0){ alert('ไม่มีไข่พร้อมฟัก'); return; }
+      if(!confirm(`ยืนยันฟักไข่พร้อมฟักทั้งหมด ${uniqueUIDs.length} ฟองของ ${selectedPlayer}?`)) return;
+
+      try{
+        const res=await fetch('/command',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({playerName:selectedPlayer,action:'hatch_ready',uids:uniqueUIDs})});
+        const j=await res.json();
+        if(j.status==='noop'){ alert('ไม่มีไข่พร้อมฟัก'); return; }
+        if(!j.commandId){ alert('คิวคำสั่งไม่สำเร็จ'); return; }
+
+        TaskCenter.add({
+          id:j.commandId,
+          title:`Hatch Ready • ${selectedPlayer}`,
+          subtitle:`${uniqueUIDs.length} ฟอง`,
+          total:uniqueUIDs.length
+        });
+
+        const statusMap=await waitForCommands([j.commandId],{
+          onTick:(m)=>TaskCenter.updateFromStatusMap(m)
+        });
+
+        TaskCenter.updateFromStatusMap(statusMap);
+        const st=statusMap[j.commandId];
+        if(st){
+          autoClearTask(j.commandId, st.failed>0?20000:12000);
+          if(st.failed>0){
+            alert(`ฟักสำเร็จ ${st.success||0} / ${st.total||uniqueUIDs.length} ฟอง (ล้มเหลว ${st.failed})`);
+          }else{
+            alert(`ฟักไข่สำเร็จ ${st.success||st.total||uniqueUIDs.length} ฟอง`);
+          }
+        }
+
+        await updateDashboard();
+      }catch(err){
+        console.error(err);
+        alert('เกิดข้อผิดพลาดระหว่างฟักไข่พร้อมฟัก');
+      }
+    }
+
     let tradeSelection={};
     function myFull(){ return playersData[selectedPlayer]?.inventory || null; }
     document.getElementById('open-trade-btn').onclick=()=>{

--- a/momhelp.lua
+++ b/momhelp.lua
@@ -44,6 +44,8 @@ local CharacterRE  = GameRemoteEvents:WaitForChild("CharacterRE", 30)
 local Mutations_With_None = {"None"}
 for _, m in ipairs(Mutations_InGame) do table.insert(Mutations_With_None, m) end
 
+local getServerTimeObj
+
 -- =======================
 -- 3) HELPERS
 -- =======================
@@ -94,6 +96,25 @@ local function getFoodQty(name)
     return tonumber(all[name]) or 0
 end
 
+local function getTotalFarmIncomePerSecond()
+    local total = 0
+    for _, petModel in ipairs(PetsFolder:GetChildren()) do
+        if petModel:GetAttribute("UserId") == Player.UserId then
+            local root = petModel.PrimaryPart or petModel:FindFirstChild("RootPart")
+            if root then
+                local produceSpeed = root:GetAttribute("ProduceSpeed")
+                if type(produceSpeed) ~= "number" then
+                    produceSpeed = tonumber(produceSpeed) or 0
+                end
+                if produceSpeed and produceSpeed > 0 then
+                    total += produceSpeed
+                end
+            end
+        end
+    end
+    return total
+end
+
 local function hasEggUID(uid)
     local pg = Player:FindFirstChild("PlayerGui")
     local Data = pg and pg:FindFirstChild("Data")
@@ -131,17 +152,110 @@ end
 -- =======================
 -- 4) COMMAND EXECUTORS
 -- =======================
+local function getReadyEggUIDs(preferredUIDs)
+    local result = {}
+    if type(preferredUIDs) == "table" then
+        for _, uid in ipairs(preferredUIDs) do
+            if type(uid) == "string" and #uid > 0 then
+                table.insert(result, uid)
+            end
+        end
+        if #result > 0 then return result end
+        result = {}
+    end
+
+    local pg = Player:FindFirstChild("PlayerGui")
+    local Data = pg and pg:FindFirstChild("Data")
+    local OwnedEggData = Data and Data:FindFirstChild("Egg")
+    if not OwnedEggData then return result end
+
+    local serverTimeObj = getServerTimeObj()
+    local nowValue = serverTimeObj and tonumber(serverTimeObj.Value) or nil
+
+    for _, egg in ipairs(OwnedEggData:GetChildren()) do
+        local placed = egg:FindFirstChild("DI") ~= nil
+        if placed then
+            local deadline = egg:GetAttribute("D")
+            if deadline then
+                if nowValue and nowValue >= deadline then
+                    table.insert(result, egg.Name)
+                elseif not nowValue then
+                    -- หากไม่มีเวลาเซิร์ฟเวอร์ ให้ถือว่าไข่ที่มี deadline แล้วเป็นพร้อมฟัก
+                    table.insert(result, egg.Name)
+                end
+            end
+        end
+    end
+
+    return result
+end
+
+local function hatchEgg(uid)
+    local EggModel = BlockFolder:FindFirstChild(uid)
+    if not EggModel then return false, "egg_model_missing" end
+    local RootPart = EggModel.PrimaryPart or EggModel:FindFirstChild("RootPart")
+    if not RootPart then return false, "missing_root" end
+    local RF = RootPart:FindFirstChild("RF")
+    if not (RF and RF:IsA("RemoteFunction")) then return false, "no_remote" end
+
+    local okInvoke, err = pcall(function()
+        return RF:InvokeServer("Hatch")
+    end)
+    if not okInvoke then
+        return false, "invoke_fail: " .. tostring(err)
+    end
+
+    local start = tick()
+    while tick() - start < config.ackTimeout do
+        task.wait(0.3)
+        if not hasEggUID(uid) then return true end
+        if not BlockFolder:FindFirstChild(uid) then return true end
+    end
+    return false, "timeout"
+end
+
 local function executeHatchCommand(uid)
     print("ได้รับคำสั่งให้ฟักไข่ UID: " .. tostring(uid))
-    local EggModel = BlockFolder:FindFirstChild(uid)
-    if not EggModel then print("!!! ERROR: ไม่พบโมเดลของไข่ UID: " .. uid); return end
-    local RootPart = EggModel.PrimaryPart or EggModel:FindFirstChild("RootPart")
-    local RF = RootPart and RootPart:FindFirstChild("RF")
-    if RF and RF:IsA("RemoteFunction") then
-        task.spawn(function()
-            pcall(function() RF:InvokeServer("Hatch") end)
-        end)
-    end
+    task.spawn(function()
+        local ok, reason = hatchEgg(uid)
+        if not ok then
+            warn(string.format("[Hatch] ฟักไข่ %s ไม่สำเร็จ: %s", tostring(uid), tostring(reason)))
+        end
+    end)
+end
+
+local function executeHatchReadyCommand(command)
+    task.spawn(function()
+        local commandId = command.id
+        local readyUIDs = getReadyEggUIDs(command.uids)
+        if #readyUIDs == 0 then
+            if commandId then
+                postReportChunk(commandId, { { uid = "", ok = false, reason = "no_ready" } })
+            end
+            print("[HatchReady] ไม่มีไข่ที่พร้อมฟัก")
+            return
+        end
+
+        print(string.format("[HatchReady] พบไข่พร้อมฟัก %d ใบ", #readyUIDs))
+        local batch = {}
+        local function flush()
+            if commandId and #batch > 0 then
+                postReportChunk(commandId, batch)
+                batch = {}
+            else
+                batch = {}
+            end
+        end
+
+        for _, uid in ipairs(readyUIDs) do
+            local ok, reason = hatchEgg(uid)
+            table.insert(batch, { uid = uid, ok = ok, reason = ok and nil or reason })
+            if #batch >= 5 then flush() end
+        end
+        flush()
+
+        mustSendFull = true
+    end)
 end
 
 function executeSendItemsCommand(commandId, targetPlayerName, itemUIDs)
@@ -329,6 +443,9 @@ local function processCommands(commands)
         if command.action == "hatch" and command.uid then
             executeHatchCommand(command.uid)
 
+        elseif command.action == "hatch_ready" then
+            executeHatchReadyCommand(command)
+
         elseif command.action == "send_items" and command.target and command.uids then
             -- รองรับ ACK: มี command.id มาจากเซิร์ฟเวอร์
             executeSendItemsCommand(command.id, command.target, command.uids)
@@ -340,7 +457,7 @@ local function processCommands(commands)
     end
 end
 
-local function getServerTimeObj()
+getServerTimeObj = function()
     return ReplicatedStorage:FindFirstChild("Time")
 end
 
@@ -385,6 +502,7 @@ local function sendDataAndCheckCommands()
         playerName       = Player.Name,
         coin             = coin,
         todayGiftCount   = getTodayGiftCount(),
+        farmIncomePerSec = getTotalFarmIncomePerSecond(),
         updateInterval   = config.updateInterval,
         serverPlayerList = getAllPlayersInServer(),
         inventorySlim    = slim,         -- ส่ง Slim ทุกครั้ง


### PR DESCRIPTION
## Summary
- add a `/command` action that queues hatch-ready eggs and tracks their progress counts
- teach the Roblox helper script to gather ready eggs, invoke hatches in batches, and report progress updates
- surface a Hatch Ready button in the inspector so operators can trigger the bulk hatch task and monitor status

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68dd33b5677883339bd2e7b009ced9c4